### PR TITLE
Adopt shared Scala CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   test:
-    uses: evolution-gaming/scala-github-actions/.github/workflows/ci.yml@2a389d2a5f4b093e72f738464bd7472bd0c3b4b8 # v6
+    uses: evolution-gaming/scala-github-actions/.github/workflows/ci.yml@e9f3a8d1d95e9ed5b762627a28a1ce93fad45f0a # v6.2.0
     with:
       scala_versions: '["2.13.18"]'
       # TODO no sbt-version-policy in this repo, so binary compatibility was never checked

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,56 +7,11 @@ on:
 
 jobs:
   test:
-
-    runs-on: ubuntu-latest
-
-    strategy:
-      fail-fast: false
-      matrix:
-        scala:
-          - 2.13.18
-
-    steps:
-      - uses: actions/checkout@v7
-
-      - uses: coursier/cache-action@95e5b1029b6b86e7bac033ee44a0697d8a527d2d # v8.1.1
-
-      - name: setup Java 17
-        uses: actions/setup-java@v5
-        with:
-          java-version: '17'
-          distribution: 'temurin'
-          cache: 'sbt'
-
-      - name: setup SBT
-        uses: sbt/setup-sbt@v1
-
-      - name: check code ${{ matrix.scala }}
-        run: sbt "++${{ matrix.scala }}; clean; check"
-
-      - name: build ${{ matrix.scala }}
-        run: sbt "++${{ matrix.scala }}; clean; coverage; testFull; coverageAggregate"
-
-      - name: locate coverage report
-        id: coverage
-        if: success()
-        run: |
-          file=$(find . -path '*/coverage-report/cobertura.xml' | head -1)
-          [ -n "$file" ] || { echo "no cobertura report was generated"; exit 1; }
-          echo "file=$file" >> "$GITHUB_OUTPUT"
-
-      - name: test coverage
-        if: success()
-        uses: coverallsapp/github-action@8d6379e14d29928660c4ba802d8e85393440b329 # v2.3.8
-        with:
-          file: ${{ steps.coverage.outputs.file }}
-          format: cobertura
-          flag-name: Scala ${{ matrix.scala }}
-
-      - name: slack
-        uses: homoluctus/slatify@master
-        if: failure() && github.ref == 'refs/heads/master'
-        with:
-          type: ${{ job.status }}
-          job_name: Build
-          url: ${{ secrets.SLACK_WEBHOOK }}
+    uses: evolution-gaming/scala-github-actions/.github/workflows/ci.yml@v6
+    secrets: inherit
+    with:
+      scala_versions: '["2.13.18"]'
+      # TODO no sbt-version-policy in this repo, so binary compatibility was never checked
+      version_policy_check: false
+      # TODO no sbt-scalafmt in this repo, so formatting was never checked
+      scalafmt_check: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,8 +7,7 @@ on:
 
 jobs:
   test:
-    uses: evolution-gaming/scala-github-actions/.github/workflows/ci.yml@v6
-    secrets: inherit
+    uses: evolution-gaming/scala-github-actions/.github/workflows/ci.yml@2a389d2a5f4b093e72f738464bd7472bd0c3b4b8 # v6
     with:
       scala_versions: '["2.13.18"]'
       # TODO no sbt-version-policy in this repo, so binary compatibility was never checked


### PR DESCRIPTION
Replaces the hand-written ci.yml with a call to the shared workflow, so tests, coverage, binary compatibility, formatting and scaladoc are configured centrally. Binary compatibility is switched off explicitly because the repo has no sbt-version-policy; it was never enforced. Same for scalafmt. Also drops the Slack step, which used the archived slatify action.

Checks now run as explicit sbt tasks rather than through the `check` alias, and checkout is unshallow so versionPolicyCheck has a previous version to compare against.

Part of evolution-gaming/scala-github-actions#5